### PR TITLE
Fix compiling with 2-call-site-sens

### DIFF
--- a/src/logic/context/2-call-site-sens+heap/constructors.dl
+++ b/src/logic/context/2-call-site-sens+heap/constructors.dl
@@ -78,23 +78,22 @@ context_item(?str)
 //-----------------------------------------------------
 // Macro-constructors
 //-----------------------------------------------------
+.decl record(?ctx: Context, ?alloc: Allocation, ?aCtx: AllocationContext)
 
-// record[Ctx, Alloc] = ACtx ->
-//    context(Ctx), allocation(Alloc), alloc_context(ACtx).
+.decl merge(?callerCtx: Context, ?invoc: Instruction, ?aCtx: AllocationContext, ?alloc: Allocation, ?calleeCtx: Context)
 
-// merge[CallerCtx, Invoc, ACtx, Alloc] = CalleeCtx ->
-//    context(CallerCtx), context(CalleeCtx),
-//    instruction(Invoc), alloc_context(ACtx), allocation(Alloc).
 
 // // Macro-definitions
-// alloc_context:new[Item] = ACtx <-
-//    record[Ctx, _] = ACtx,
-//    context:new[_, Item] = Ctx.
 
-// context:new[LastItem, NewItem] = CalleeCtx <-
-//    merge[CallerCtx, Invoc, _, _] = CalleeCtx,
-//    context:new[_, LastItem] = CallerCtx,
-//    context_item:by_invoc[Invoc] = NewItem.
+alloc_context_new(?item, ?aCtx) :-
+   record(?ctx, _, ?aCtx),
+   context_new(?item, ?ctx).
+
+
+context_new(?newItem, ?calleeCtx) :-
+   merge(?callerCtx, ?invoc, _, _, ?calleeCtx),
+   context_new(_,?callerCtx),
+   context_item_by_invoc(?invoc, ?newItem).
 
 //-----------------------------------------------------
 // Unpacking context items

--- a/src/logic/export/generate-output.dl
+++ b/src/logic/export/generate-output.dl
@@ -436,10 +436,7 @@
 .output ptrtoint_instruction_from_type
 .output ptx_device_calling_convention
 .output ptx_kernel_calling_convention
-.output reachable_context1
-.output reachable_context2
-.output reachable_context3
-.output reachable_context4
+.output reachable_context
 .output reachable_function
 .output reachable_instruction
 .output reachable_load

--- a/src/logic/master.project
+++ b/src/logic/master.project
@@ -5,5 +5,5 @@
 #include "export/export.project"
 #include "points-to/points-to.project"
 //#include "context/insensitive/insensitive.project"
-#include "context/1-call-site-sens+heap/1-call-site-sens+heap.project"
-//#include "context/2-call-site-sens+heap/2-call-site-sens+heap.project"
+// #include "context/1-call-site-sens+heap/1-call-site-sens+heap.project"
+#include "context/2-call-site-sens+heap/2-call-site-sens+heap.project"


### PR DESCRIPTION
Remove dead code and fix compiling using [1-call-site](https://github.com/EvanKaraf/cclyzer-souffle/blob/7c6ef84684e80c597ace8f103f164536475df98b/src/logic/context/1-call-site-sens%2Bheap/constructors.dl#L1) as a template